### PR TITLE
fix: make StringImpl.clone trusted

### DIFF
--- a/source/bc/string/string.d
+++ b/source/bc/string/string.d
@@ -261,7 +261,7 @@ private struct StringImpl(C, RC rc, Zero zero)
         }
 
         /// Copy constructor
-        this(ref return scope StringImpl rhs) pure
+        this(ref return scope StringImpl rhs) pure @safe
         {
             if (rhs.pay)
             {
@@ -315,7 +315,7 @@ private struct StringImpl(C, RC rc, Zero zero)
         }
 
         ///
-        StringImpl clone() scope
+        StringImpl clone() scope @trusted
         {
             return StringImpl(this[]);
         }


### PR DESCRIPTION
This fixes this error when `dip1000` is used
```d
\bc-string\source\bc\string\string.d(320,31): Error: scope variable `this` assigned to non-scope parameter `this` calling bc.string.string.StringImpl!(char, RC.no, Zero.no).StringImpl.opSlice
\bc-string\source\bc\string\string.d(216,16): Error: template instance `bc.string.string.StringImpl!(char, RC.no, Zero.no)` error instantiating
ldc2 failed with exit code 1.
```